### PR TITLE
add outreach.io integration

### DIFF
--- a/sources/example-webhooks/mailing.json
+++ b/sources/example-webhooks/mailing.json
@@ -1,0 +1,15 @@
+{
+  "payload": {
+    "headers": {},
+    "queryParams": {},
+    "body": {
+      "attributes": {
+        "openCount": 12,
+        "updatedAt": "2019-06-28T07:45:42.000Z"
+      },
+      "id": 957993,
+      "relationships": {},
+      "type": "mailing"
+    }
+  }
+}

--- a/sources/example-webhooks/prospect.json
+++ b/sources/example-webhooks/prospect.json
@@ -1,0 +1,15 @@
+{
+  "payload": {
+    "headers": {},
+    "queryParams": {},
+    "body": {
+      "attributes": {
+        "engagedAt": "2019-06-28T07:45:49.000Z",
+        "updatedAt": "2019-06-28T07:45:53.000Z"
+      },
+      "id": 581130,
+      "relationships": {},
+      "type": "prospect"
+    }
+  }
+}

--- a/sources/handler.js
+++ b/sources/handler.js
@@ -1,0 +1,15 @@
+exports.processEvents = async (event) => {
+    let eventBody = event.payload.body;
+
+    let returnValue = {
+        events: [{
+            type: "track",
+            userId: "unknown",
+            event: eventBody.type,
+            properties: eventBody.attributes
+        }],
+        objects: []
+    }
+
+    return returnValue
+}


### PR DESCRIPTION
this adds a source function for outreach.io

outreach.io doesn't appear to be sending any email or user identifiers in its events, so I've left the userId hardcoded to "unknown" for now.

Reference: https://api.outreach.io/api/v2/docs