### PR TITLE
HelpScout integration example

### DIFF
--- a/sources/helpscout/handlers.js
+++ b/sources/helpscout/handlers.js
@@ -1,44 +1,46 @@
 // 1. Access your event body, headers and query parameters through the event object
 // 2. Transform the event into Segment Tracking Events or Objects by returning an object with the appropriate keys
 
+//NOT FOR PRODUCTION USE
+
+//TODO: verify Helpscout signature
+
 exports.processEvents = async (event) => {
   let eventBody = event.payload.body;
   let eventHeaders = event.payload.headers;
   let queryParameters = event.payload.queryParameters;
+  
+  console.log(eventHeaders['X-Helpscout-Event'][0]);
+  
+  let eventType = eventHeaders['X-Helpscout-Event'][0].split('.')[0]
+  
+  console.log(eventType);
+  
+  let type = ''
 
-  // Return an object with any combination of the following keys
+  if (eventType == 'convo') {
+    type = 'conversation'
+  } else if (eventType == 'customer') {
+    type = 'customer'
+  } else if (eventType == 'satisfaction') {
+    type = 'rating'
+  } else {
+    callback(new Error('No matching event type (must be one of Conversation, Customer, Rating)'))
+  }
+  
+  console.log(type);
+
   let returnValue = {
-    events: [{
-        type: 'identify',
-        userId: '1234',
-        properties: {
-          propertyName: 'Example Property'
-        }
-    },
-    {
-        type: 'track',
-        event: 'Event Name',
-        userId: '1234',
-        properties: {
-          propertyName: 'Example Property'
-        }
-    },
-    {
-        type: 'group',
-        userId: '1234',
-        groupId: '1234',
-        properties: {
-          propertyName: 'Example Property'
-        }
-    }],
     objects: [{
-      collection: 'Collection Name - Plural',
-      id: "String of Object ID",
+      collection: type,
+      id: eventBody.id.toString(),
       properties: {
-        propertyName: 'Example Property'
+        type: eventBody.type
       }
     }]
   }
+  
+  console.log(returnValue);
 
   // Return the Javascript object with a key of events, objects or both
   return(returnValue)

--- a/sources/helpscout/handlers.js
+++ b/sources/helpscout/handlers.js
@@ -1,0 +1,45 @@
+// 1. Access your event body, headers and query parameters through the event object
+// 2. Transform the event into Segment Tracking Events or Objects by returning an object with the appropriate keys
+
+exports.processEvents = async (event) => {
+  let eventBody = event.payload.body;
+  let eventHeaders = event.payload.headers;
+  let queryParameters = event.payload.queryParameters;
+
+  // Return an object with any combination of the following keys
+  let returnValue = {
+    events: [{
+        type: 'identify',
+        userId: '1234',
+        properties: {
+          propertyName: 'Example Property'
+        }
+    },
+    {
+        type: 'track',
+        event: 'Event Name',
+        userId: '1234',
+        properties: {
+          propertyName: 'Example Property'
+        }
+    },
+    {
+        type: 'group',
+        userId: '1234',
+        groupId: '1234',
+        properties: {
+          propertyName: 'Example Property'
+        }
+    }],
+    objects: [{
+      collection: 'Collection Name - Plural',
+      id: "String of Object ID",
+      properties: {
+        propertyName: 'Example Property'
+      }
+    }]
+  }
+
+  // Return the Javascript object with a key of events, objects or both
+  return(returnValue)
+}


### PR DESCRIPTION
This is a non-production example of a HelpScout custom source function.

For this to be production ready, we would need to validate that the request is coming from HelpScout, and do a better job of mapping their request data into our properties.