### PR TITLE
Add wavefront custom destination (+fix tests)

### DIFF
--- a/buildpack/boreal/index.js
+++ b/buildpack/boreal/index.js
@@ -99,7 +99,7 @@ exports.processSourcePayload = async payload => {
 
     const request = new ServerRequest(body, { headers, url });
     let settings = payload.hasOwnProperty("settings") ? payload.settings : {};
-    await fn(request, payload.settings);
+    await fn(request, settings);
 
     // collect and reset implicit messages
     const { events, objects } = Segment

--- a/buildpack/boreal/index.js
+++ b/buildpack/boreal/index.js
@@ -98,6 +98,7 @@ exports.processSourcePayload = async payload => {
     }
 
     const request = new ServerRequest(body, { headers, url });
+    let settings = payload.hasOwnProperty("settings") ? payload.settings : {};
     await fn(request, payload.settings);
 
     // collect and reset implicit messages

--- a/buildpack/boreal/index.js
+++ b/buildpack/boreal/index.js
@@ -98,7 +98,7 @@ exports.processSourcePayload = async payload => {
     }
 
     const request = new ServerRequest(body, { headers, url });
-    let settings = payload.hasOwnProperty("settings") ? payload.settings : {};
+    let settings = payload.settings || {};
     await fn(request, settings);
 
     // collect and reset implicit messages

--- a/destinations/adobe-target/handler.js
+++ b/destinations/adobe-target/handler.js
@@ -38,6 +38,9 @@ let profileApiAuthHeaders = new Headers({
   })
 
 async function onIdentify(event, settings) {
+  //Check mandatory config
+  if(!checkMandatoryConfig())
+    throw new ValidationError("Adobe and Profile API mandatory credentials were not set")
   
   // first, grab adobe target mbox PCID. if it doesn't exist, this user cannot be updated in adobe target.
   // replace userId to fetch from Personas
@@ -65,4 +68,8 @@ async function onIdentify(event, settings) {
     method: "GET"
   })
   return await targetProfileUpdateUrl.text
+}
+
+function checkMandatoryConfig() {
+  return !!adobeClientCode && !!adobeIdTraitName && !!profileSpaceID && !!profileApiToken;
 }

--- a/destinations/wavefront/README.md
+++ b/destinations/wavefront/README.md
@@ -1,0 +1,8 @@
+# PURPOSE
+This custom destination allows you to send user events to Wavefront's events [system](https://docs.wavefront.com/events.html). This allows you to correlate user events with other system or app metrics and help troubleshoot issues faster. 
+
+# What do you need?
+
+1. Update API key in settings of custom function
+2. Update wavefrontInstance on Line 7 to your own
+3. Save and Enjoy :)

--- a/destinations/wavefront/handler.js
+++ b/destinations/wavefront/handler.js
@@ -9,8 +9,7 @@ let wavefrontApiVersion = "v2";
 let wavefrontResource = "event";
 
 //Create endpoint
-const endpoint = `https://${wavefrontInstance}.wavefront.com/api/${wavefrontApiVersion}/${wavefrontResource}`;
-const url = new URL(endpoint);
+const url = new URL(`https://${wavefrontInstance}.wavefront.com/api/${wavefrontApiVersion}/${wavefrontResource}`);
 
 //Properties we need in the track event
 //Note 1: we only cover instantaneous events for now as ending events later is only possible via wavefront UI manually
@@ -47,8 +46,7 @@ async function onTrack(event, settings) {
     annotations
   };
 
-  //TODO: Is there a reason to create URL object and then stringify again?
-  const res = await fetch(url.toString(), {
+  const res = await fetch(url, {
     body: JSON.stringify(body),
     headers: new Headers({
       "Authorization": `Bearer ${settings.apiKey}`,

--- a/destinations/wavefront/handler.js
+++ b/destinations/wavefront/handler.js
@@ -1,0 +1,127 @@
+
+// This example hits the WAVEFRONT REST API V2 events endpoint
+// Note 1: The wavefront instance name is different for each customer
+// Note 2: v2 is the only supported version as of 1/15/2020
+
+//TODO: Move these to settings once more than apiKey is supported
+let wavefrontInstance = "longboard";
+let wavefrontApiVersion = "v2";
+let wavefrontResource = "event";
+
+//Create endpoint
+const endpoint = `https://${wavefrontInstance}.wavefront.com/api/${wavefrontApiVersion}/${wavefrontResource}`;
+const url = new URL(endpoint);
+
+//Properties we need in the track event
+//Note 1: we only cover instantaneous events for now as ending events later is only possible via wavefront UI manually
+//Note 2: startTime and endTime are just set to timestamp
+//TODO: Convert some important context properties to tags
+const annotationProperties = [
+    { key: "type", validateFunc: (input) => { return _.isString(input)} },
+    { key: "details", validateFunc: (input) => { return _.isString(input)} },
+    { key: "severity", validateFunc: (input) => { return _.isString(input) && _.indexOf(["Info", "Warn", "Severe"], input) > -1 } }];
+
+/**
+ * @param {SpecTrack} event The track event
+ * @param {Object.<string, any>} settings Custom settings
+ * @return void
+ */
+async function onTrack(event, settings) {
+  let { properties, timestamp } = event;
+
+  let eventName = event.event;
+  let timestampInSeconds = Date.parse(timestamp);
+  let annotations = {
+      prettyName: eventName
+  };
+  annotationProperties.forEach(subproperty => {
+    let { key, validateFunc } = subproperty;
+    if(properties.hasOwnProperty(key) && validateFunc(properties[key]))
+      annotations[key] = properties[key];
+  });
+
+  let body = {
+    name: eventName,
+    startTime: timestampInSeconds,
+    endTime: timestampInSeconds + 1,
+    annotations
+  };
+
+  //TODO: Remove me
+  console.log(body);
+
+  //TODO: Is there a reason to create URL object and then stringify again?
+  const res = await fetch(url.toString(), {
+    body: JSON.stringify(body),
+    headers: new Headers({
+      "Authorization": `Bearer ${settings.apiKey}`,
+      "Content-Type": "application/json",
+      "Accept": "application/json"
+    }),
+    method: "post",
+  })
+
+  //TODO: how to report errors?
+  //Note 1: API returns 200 even when validation errors occur
+  //Note 2: API is returning JSON but setting the response type to plain/text
+  return await res.text() // or res.json() for JSON APIs
+}
+
+/**
+ * onIdentify takes an Identify event, but wavefront events have no concept of user info
+ *
+ * @param {SpecIdentify} event The identify event
+ * @param {Object.<string, any>} settings Custom settings
+ * @return any
+ */
+async function onIdentify(event, settings) {
+    throw new EventNotSupported("alias not supported")
+}
+
+/**
+ * onGroup not supported
+ *
+ * @param {SpecGroup} event The group event
+ * @param {Object.<string, any>} settings Custom settings
+ * @return any
+ */
+async function onGroup(event, settings) {
+    throw new EventNotSupported("alias not supported")
+}
+
+/**
+ * onPage not supported
+ *
+ * @param {SpecPage} event The page event
+ * @param {Object.<string, any>} settings Custom settings
+ * @return any
+ */
+// page demonstrates how to handle an invalid setting
+//TODO: doesn't this get covered by onTrack?
+async function onPage(event, settings) {
+    throw new EventNotSupported("page not supported")
+}
+
+/**
+ * onAlias not supported
+ *
+ * @param {SpecAlias} event The alias event
+ * @param {Object.<string, any>} settings Custom settings
+ * @return any
+ */
+async function onAlias(event, settings) {
+  throw new EventNotSupported("alias not supported")
+}
+
+
+/**
+ * onScreen not supported
+ *
+ * @param {SpecScreen} event The screen event
+ * @param {Object.<string, any>} settings Custom settings
+ * @return any
+ */
+//TODO: doesn't this get covered by onTrack?
+async function onScreen(event, settings) {
+   throw new EventNotSupported("screen not supported")
+}

--- a/destinations/wavefront/handler.js
+++ b/destinations/wavefront/handler.js
@@ -19,7 +19,7 @@ const url = new URL(endpoint);
 const annotationProperties = [
     { key: "type", validateFunc: (input) => { return _.isString(input)} },
     { key: "details", validateFunc: (input) => { return _.isString(input)} },
-    { key: "severity", validateFunc: (input) => { return _.isString(input) && _.indexOf(["Info", "Warn", "Severe"], input) > -1 } }];
+    { key: "severity", validateFunc: (input) => { return _.isString(input) && _.indexOf(["info", "warn", "severe"], input) > -1 } }];
 
 /**
  * @param {SpecTrack} event The track event

--- a/sources.test.js
+++ b/sources.test.js
@@ -1,6 +1,7 @@
 var fs = require('fs')
 const process = require('process')
 const { processSourcePayload } = require('./buildpack/boreal')
+const { EventNotSupported, InvalidEventPayload, ValidationError } = require('./buildpack/boreal/window')
 
 const sources = fs.readdirSync(`${__dirname}/sources`)
 const skips = ["leanplum"]

--- a/sources.test.js
+++ b/sources.test.js
@@ -27,7 +27,13 @@ describe.each(sources)("%s", (source) => {
 
     tester.each(payloads)("%s handler", async (example, payload) => {
         process.chdir(dir)
-        const messages = await processSourcePayload(payload)
-        expect(messages.events.length + messages.objects.length).toBeGreaterThanOrEqual(0)
+        try {
+            const messages = await processSourcePayload(payload)
+            expect(messages.events.length + messages.objects.length).toBeGreaterThanOrEqual(0)
+        } catch(err) {
+            if (!(err instanceof EventNotSupported || err instanceof ValidationError || err instanceof InvalidEventPayload)) {
+                fail(err)
+            }
+        }
     })
 })


### PR DESCRIPTION
I added a custom destination to Wavefront which is very similar to Datadog. It allows you to push user events into wavefront and then you can overlay user events with other system or app metrics and correlate them for troubleshooting purposes.