### PR TITLE
Add New Relic destination

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,16 +26,16 @@ this repo as the set of examples.
 - [Talkable](./sources/talkable) - Subscribes to Talkable webhooks
 - [Typeform](./sources/typeform) - Subscribes to Typeform webhooks
 
-
 ## Destinations
 
 - [Airtable](./destinations/airtable) - Capture user feedback and send through to your Airtable
+- [Datadog](./destinations/datadog) - Sends a metric to datadog with high level message/event type as tags
 - [Follow Along](./destinations/follow-along) - Generates Fullstory links and sends to Slack
+- [New Relic](./destinations/new-alongrelic) - Sends events to New Relic Event API
+- [Optimizely](./destinations/optimizely) - Sends conversion metrix to Optimizely
 - [Requestbin](./destinations/requestbin) - Sends events to RequestBin for introspection
 - [Slack](./destinations/slack) - Adds a Gravatar icon to events with an email and sends messages to Slack
 - [Zendesk](./destinations/zendesk) - Create new Zendesk tickets triggered by events that you send
-- [Datadog](./destinations/datadog) - Sends a metric to datadog with high level message/event type as tags
-- [Optimizely](./destinations/optimizely) - Sends conversion metrix to optimizely.
 
 ## Development
 

--- a/destinations/new-relic/Readme.md
+++ b/destinations/new-relic/Readme.md
@@ -1,0 +1,9 @@
+# New Relic Custom Destination Function
+
+This function forwards all Segment `track` API calls to [New Relic Event API](https://docs.newrelic.com/docs/telemetry-data-platform/ingest-manage-data/ingest-apis/use-event-api-report-custom-events).
+
+## Settings
+
+- `accountId` (string) Your New Relic Insights account ID
+- `insertKey` (string) Your New Relic Insert Key
+- `useEuRegionEndpoint` (boolean) Toggle this option if your New Relic account is hosted in the EU region data center. Defaults to `false`.

--- a/destinations/new-relic/handler.js
+++ b/destinations/new-relic/handler.js
@@ -1,0 +1,42 @@
+// Learn more about destination functions API at
+// https://segment.com/docs/connections/destinations/destination-functions
+
+/**
+ * Handle track event
+ * @param  {SegmentTrackEvent} event
+ * @param  {FunctionSettings} settings
+ */
+async function onTrack(event, settings) {
+  // Learn more at https://segment.com/docs/connections/spec/track/
+
+  const endpoint = settings.useEuRegionEndpoint
+    ? `https://insights-collector.eu01.nr-data.net/v1/accounts/${settings.accountId}/events`
+    : `https://insights-collector.newrelic.com/v1/accounts/${settings.accountId}/events`;
+
+  const newRelicEvent = {
+    event: event.event,
+    eventType: 'Segment',
+    ...event.properties,
+  };
+
+  let response;
+
+  try {
+    response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'X-Insert-Key': settings.insertKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(newRelicEvent),
+    });
+  } catch (error) {
+    // Retry on connection error
+    throw new RetryError(error.message);
+  }
+
+  if (response.status >= 500 || response.status === 429) {
+    // Retry on 5xx (server errors) and 429s (rate limits)
+    throw new RetryError(`Failed with ${response.status}`);
+  }
+}


### PR DESCRIPTION
Hi there,

At [MoonPay](https://www.moonpay.io/), we recently migrated our New Relic account to their EU data centre and our Segment integration with [the official Segment destination](https://segment.com/docs/connections/destinations/catalog/new-relic/) broke as the only supported endpoint is the US one.

This small function allows to switch between the EU and US endpoint and mimics what's being done on the official New Relic destination.

We have been running this function in production for a couple of hours now, no errors are reported on Segment and data is accessible on New Relic.

I've also cleaned up the repo README file to sort all the destinations alphabetically.